### PR TITLE
feat: unify model lifecycle and async pipeline

### DIFF
--- a/docs/pipeline/README.md
+++ b/docs/pipeline/README.md
@@ -1,0 +1,3 @@
+# 运行管线整理
+
+- [`run_rag_system.py`](../../run_rag_system.py) 统一从配置文件读取模型与数据库参数，`process_data` 异步驱动文本处理，`build_knowledge_base` 复用已加载的向量数据并动态推断维度，确保脚本与前端共享一致配置。

--- a/run_rag_system.py
+++ b/run_rag_system.py
@@ -114,39 +114,6 @@ class RAGSystemRunner:
         
         return success
 
-    async def run_full_pipeline(self, args):
-        """运行完整的RAG系统流程"""
-        logger.info("🚀 开始运行完整的RAG系统流程...")
-        start_time = time.time()
-        
-        # 1. 环境检查 (可以根据需要保留或简化)
-        
-        # 2. 数据收集
-        if not args.skip_collect:
-            if not await self.collect_data(args.max_papers, args.days_back):
-                logger.error("❌ 数据收集失败")
-                return False
-        
-        # 3. 数据处理
-        if not args.skip_process:
-            if not await self.process_data():
-                logger.error("❌ 数据处理失败") 
-                return False
-        
-        # 4. 构建知识库
-        if not args.skip_build:
-            if not self.build_knowledge_base():
-                logger.error("❌ 知识库构建失败")
-                return False
-
-        logger.info(f"✅ RAG系统准备完成! 总耗时: {time.time() - start_time:.1f}秒")
-        
-        # 5. 启动前端
-        if not args.no_frontend:
-            self.launch_frontend(args.port)
-        
-        return True
-    
     async def collect_data(self, max_papers: int = 50, days_back: int = 7) -> bool:
         """数据收集步骤"""
         logger.info("📥 开始数据收集...")
@@ -191,17 +158,20 @@ class RAGSystemRunner:
             logger.info(f"📄 加载到 {len(documents)} 个文档")
             
             # 初始化处理器
-            config = {
-                'chunk_size': 512,
-                'overlap': 50,
-                'embedding_model': 'BAAI/bge-m3',
-                'device': 'auto'
+            processor_config = {
+                'chunk_size': config.CHUNK_SIZE,
+                'chunk_overlap': config.CHUNK_OVERLAP,
+                'embedding_model': config.EMBEDDING_MODEL,
+                'device': config.DEVICE,
+                'enable_multi_representation': config.ENABLE_MULTI_REPRESENTATION,
+                'llm_model': config.LLM_MODEL,
+                'HUGGING_FACE_TOKEN': config.HUGGING_FACE_TOKEN
             }
-            
-            processor = TextProcessor(config)
-            
+
+            processor = TextProcessor(processor_config)
+
             # 处理文档
-            chunks = processor.process_documents(documents)
+            chunks = await processor.process_documents(documents)
             
             if not chunks:
                 logger.error("❌ 文档处理失败，没有生成有效的文本块")
@@ -231,18 +201,26 @@ class RAGSystemRunner:
                 logger.error(f"❌ 找不到处理后的数据文件: {processed_file}")
                 return False
             
-            # 初始化数据库管理器
-            config = {
-                'qdrant_host': 'localhost',
-                'qdrant_port': 6333,
-                'collection_name': 'ai_papers',
-                'vector_size': 1024
+            with open(processed_file, 'r', encoding='utf-8') as f:
+                processed_chunks = json.load(f)
+
+            sample_vector = next((chunk.get('embedding') for chunk in processed_chunks if chunk.get('embedding')), None)
+            vector_size = len(sample_vector) if sample_vector else 0
+            if not vector_size:
+                vector_size = 1024  # 合理的默认值
+
+            db_config = {
+                'qdrant_host': config.QDRANT_HOST,
+                'qdrant_port': config.QDRANT_PORT,
+                'collection_name': config.COLLECTION_NAME,
+                'vector_size': vector_size,
+                'qdrant_timeout': getattr(config, 'QDRANT_TIMEOUT', 120)
             }
-            
-            db_manager = VectorDatabaseManager(config)
-            
+
+            db_manager = VectorDatabaseManager(db_config)
+
             # 构建知识库
-            success = db_manager.build_knowledge_base(processed_file)
+            success = db_manager.build_knowledge_base(processed_file, chunks=processed_chunks)
             
             if success:
                 # 显示统计信息
@@ -267,18 +245,18 @@ class RAGSystemRunner:
             from src.generation.rag_generator import RAGSystem
             from src.retrieval.vector_database import VectorDatabaseManager
             
-            # 初始化系统
-            config = {
-                'embedding_model': 'BAAI/bge-m3',
-                'llm_model': 'Qwen/Qwen2-7B-Instruct',
-                'device': 'auto',
-                'qdrant_host': 'localhost',
-                'qdrant_port': 6333,
-                'collection_name': 'ai_papers'
+            rag_settings = {
+                'embedding_model': config.EMBEDDING_MODEL,
+                'llm_model': config.LLM_MODEL,
+                'device': config.DEVICE,
+                'qdrant_host': config.QDRANT_HOST,
+                'qdrant_port': config.QDRANT_PORT,
+                'collection_name': config.COLLECTION_NAME,
+                'HUGGING_FACE_TOKEN': config.HUGGING_FACE_TOKEN
             }
-            
-            rag_system = RAGSystem(config)
-            db_manager = VectorDatabaseManager(config)
+
+            rag_system = RAGSystem(rag_settings)
+            db_manager = VectorDatabaseManager(rag_settings)
             rag_system.set_database(db_manager)
             
             # 测试查询

--- a/src/data_ingestion/README.md
+++ b/src/data_ingestion/README.md
@@ -1,0 +1,3 @@
+# 数据采集改进
+
+- [`multi_source_collector.py`](./multi_source_collector.py) 在 `collect_all` 与 `fetch_arxiv_papers` 中复用单一 `aiohttp.ClientSession`，并在 `_process_single_pdf` 里共享连接池下载 PDF，提高高并发场景下的抓取效率。

--- a/src/data_ingestion/multi_source_collector.py
+++ b/src/data_ingestion/multi_source_collector.py
@@ -62,14 +62,15 @@ class MultiSourceCollector:
     async def collect_all(self, days_back: int = 7) -> List[Document]:
         """从所有配置的数据源并行收集数据"""
         logger.info("🚀 Starting data collection from all sources...")
-        
-        tasks = [
-            self.fetch_arxiv_papers(days_back=days_back),
-            self.fetch_huggingface_papers(),
-            self.fetch_blog_posts()
-        ]
 
-        results = await asyncio.gather(*tasks, return_exceptions=True)
+        async with aiohttp.ClientSession() as session:
+            tasks = [
+                self.fetch_arxiv_papers(session, days_back=days_back),
+                self.fetch_huggingface_papers(),
+                self.fetch_blog_posts()
+            ]
+
+            results = await asyncio.gather(*tasks, return_exceptions=True)
         
         all_docs = []
         for res in results:
@@ -93,31 +94,30 @@ class MultiSourceCollector:
         logger.info(f"💾 Raw data saved to {self.raw_data_path}")
 
     # --- ArXiv Collector ---
-    async def fetch_arxiv_papers(self, query: str = "cat:cs.AI OR cat:cs.CL OR cat:cs.LG", days_back: int = 7) -> List[Document]:
+    async def fetch_arxiv_papers(self, session: aiohttp.ClientSession, query: str = "cat:cs.AI OR cat:cs.CL OR cat:cs.LG", days_back: int = 7) -> List[Document]:
         logger.info("🔍 Collecting from ArXiv...")
         base_url = "http://export.arxiv.org/api/query"
         params = {
             'search_query': query, 'start': 0, 'max_results': 100,
             'sortBy': 'submittedDate', 'sortOrder': 'descending'
         }
-        
-        async with aiohttp.ClientSession() as session:
-            try:
-                async with session.get(base_url, params=params) as response:
-                    if response.status != 200:
-                        logger.error(f"ArXiv API request failed: {response.status}")
-                        return []
-                    
-                    xml_content = await response.text()
-                    parsed_papers = self._parse_arxiv_response(xml_content, days_back)
-                    
-                    # 下载并解析PDF
-                    processed_papers = await self.download_and_extract_pdfs(parsed_papers)
-                    logger.success(f"ArXiv collection successful: {len(processed_papers)} papers.")
-                    return processed_papers
-            except Exception as e:
-                logger.error(f"Error fetching ArXiv papers: {e}")
-                return []
+
+        try:
+            async with session.get(base_url, params=params) as response:
+                if response.status != 200:
+                    logger.error(f"ArXiv API request failed: {response.status}")
+                    return []
+
+                xml_content = await response.text()
+                parsed_papers = self._parse_arxiv_response(xml_content, days_back)
+
+                # 下载并解析PDF
+                processed_papers = await self.download_and_extract_pdfs(parsed_papers, session)
+                logger.success(f"ArXiv collection successful: {len(processed_papers)} papers.")
+                return processed_papers
+        except Exception as e:
+            logger.error(f"Error fetching ArXiv papers: {e}")
+            return []
     
     def _parse_arxiv_response(self, xml_content: str, days_back: int) -> List[Dict]:
         """解析ArXiv API的XML响应"""
@@ -148,28 +148,27 @@ class MultiSourceCollector:
             })
         return papers
 
-    async def download_and_extract_pdfs(self, papers: List[Dict]) -> List[Document]:
+    async def download_and_extract_pdfs(self, papers: List[Dict], session: aiohttp.ClientSession) -> List[Document]:
         """并发下载PDF并提取文本"""
         semaphore = asyncio.Semaphore(5)
-        tasks = [self._process_single_pdf(paper, semaphore) for paper in papers]
+        tasks = [self._process_single_pdf(paper, semaphore, session) for paper in papers]
         results = await asyncio.gather(*tasks)
         return [doc for doc in results if doc]
 
-    async def _process_single_pdf(self, paper_meta: Dict, semaphore: asyncio.Semaphore) -> Optional[Document]:
+    async def _process_single_pdf(self, paper_meta: Dict, semaphore: asyncio.Semaphore, session: aiohttp.ClientSession) -> Optional[Document]:
         """处理单个PDF的下载和文本提取"""
         async with semaphore:
             pdf_path = self.pdf_dir / f"{paper_meta['id']}.pdf"
             try:
                 # Download PDF
                 if not pdf_path.exists():
-                    async with aiohttp.ClientSession() as session:
-                        async with session.get(paper_meta['pdf_url']) as response:
-                            if response.status == 200:
-                                with open(pdf_path, 'wb') as f:
-                                    f.write(await response.read())
-                            else:
-                                logger.warning(f"Failed to download {paper_meta['pdf_url']}")
-                                return None
+                    async with session.get(paper_meta['pdf_url']) as response:
+                        if response.status == 200:
+                            with open(pdf_path, 'wb') as f:
+                                f.write(await response.read())
+                        else:
+                            logger.warning(f"Failed to download {paper_meta['pdf_url']}")
+                            return None
                 
                 # Extract text
                 extracted_text = self._extract_text_from_pdf(pdf_path)

--- a/src/evaluation/README.md
+++ b/src/evaluation/README.md
@@ -1,0 +1,3 @@
+# 评估透明化
+
+- [`comprehensive_evaluation.py`](./comprehensive_evaluation.py) 在 `EvaluationMetrics` 中增加 `notes` 字段，当 RAGAS 或 TruLens 回退到模拟结果时，通过 `using_mock` 标记并在报告中记录提示，防止误读评分。

--- a/src/evaluation/comprehensive_evaluation.py
+++ b/src/evaluation/comprehensive_evaluation.py
@@ -6,7 +6,7 @@
 """
 
 from typing import Dict, List, Optional, Any, Tuple
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 import asyncio
 import time
 import json
@@ -66,10 +66,11 @@ class EvaluationMetrics:
     response_latency: Optional[float] = None
     cost_efficiency: Optional[float] = None
     user_satisfaction: Optional[float] = None
-    
+
     # 综合指标
     overall_score: Optional[float] = None
     evaluation_timestamp: str = None
+    notes: List[str] = field(default_factory=list)
     
     def __post_init__(self):
         if self.evaluation_timestamp is None:
@@ -100,13 +101,14 @@ class EvaluationReport:
 
 class RAGASEvaluator:
     """RAGAS评估器"""
-    
+
     def __init__(self, llm_model=None):
+        self.llm_model = llm_model
+        self.using_mock = not RAGAS_AVAILABLE
         if not RAGAS_AVAILABLE:
             logger.warning("RAGAS not available, creating mock evaluator")
             return
-        
-        self.llm_model = llm_model
+
         self.metrics = [
             faithfulness,
             answer_relevancy,
@@ -120,8 +122,9 @@ class RAGASEvaluator:
     async def evaluate_batch(self, evaluation_cases: List[EvaluationCase]) -> Dict[str, float]:
         """批量评估"""
         if not RAGAS_AVAILABLE:
+            self.using_mock = True
             return self._mock_ragas_evaluation()
-        
+
         try:
             # 准备数据集
             dataset = self._prepare_ragas_dataset(evaluation_cases)
@@ -132,11 +135,13 @@ class RAGASEvaluator:
                 metrics=self.metrics,
                 llm=self.llm_model
             )
-            
+
+            self.using_mock = False
+
             # 提取分数
             return {
                 'faithfulness': results['faithfulness'],
-                'answer_relevancy': results['answer_relevancy'], 
+                'answer_relevancy': results['answer_relevancy'],
                 'context_precision': results['context_precision'],
                 'context_recall': results['context_recall'],
                 'answer_correctness': results['answer_correctness'],
@@ -145,8 +150,9 @@ class RAGASEvaluator:
             
         except Exception as e:
             logger.error(f"RAGAS evaluation failed: {e}")
+            self.using_mock = True
             return self._mock_ragas_evaluation()
-    
+
     def _prepare_ragas_dataset(self, evaluation_cases: List[EvaluationCase]) -> Dataset:
         """准备RAGAS数据集"""
         data = {
@@ -172,12 +178,13 @@ class RAGASEvaluator:
 
 class TruLensEvaluator:
     """TruLens评估器"""
-    
+
     def __init__(self, rag_chain=None):
+        self.using_mock = not TRULENS_AVAILABLE or rag_chain is None
         if not TRULENS_AVAILABLE:
             logger.warning("TruLens not available, creating mock evaluator")
             return
-        
+
         self.rag_chain = rag_chain
         
         # 初始化反馈函数
@@ -196,24 +203,28 @@ class TruLensEvaluator:
     async def evaluate_real_time(self, question: str, answer: str, context: str) -> Dict[str, float]:
         """实时评估"""
         if not TRULENS_AVAILABLE or not self.rag_chain:
+            self.using_mock = True
             return self._mock_trulens_evaluation()
-        
+
         try:
             # TruLens实时评估
             with self.tru_rag as recording:
                 result = await self.rag_chain.ainvoke(question)
-            
+
             # 获取反馈分数
             record = recording.get()
             scores = {}
-            
+
             for feedback_result in record.feedback_results:
                 scores[feedback_result.name] = feedback_result.score
-            
+
+            self.using_mock = False
+
             return scores
-            
+
         except Exception as e:
             logger.error(f"TruLens evaluation failed: {e}")
+            self.using_mock = True
             return self._mock_trulens_evaluation()
     
     def _mock_trulens_evaluation(self) -> Dict[str, float]:
@@ -411,12 +422,16 @@ class ComprehensiveEvaluator:
             metrics.context_recall_score = ragas_scores.get('context_recall')
             metrics.answer_correctness_score = ragas_scores.get('answer_correctness')
             metrics.answer_similarity_score = ragas_scores.get('answer_similarity')
-        
+        if getattr(self.ragas_evaluator, 'using_mock', False):
+            metrics.notes.append("RAGAS未安装或执行失败，已返回模拟评分。")
+
         # TruLens结果
         if len(results) > 1 and isinstance(results[1], dict):
             trulens_scores = results[1]
             metrics.groundedness_score = trulens_scores.get('groundedness')
             metrics.qa_relevance_score = trulens_scores.get('qa_relevance')
+        if getattr(self.trulens_evaluator, 'using_mock', False):
+            metrics.notes.append("TruLens未启用，使用模拟指标作为占位。")
         
         # 自定义指标结果
         if len(results) > 2 and isinstance(results[2], dict):

--- a/src/generation/README.md
+++ b/src/generation/README.md
@@ -1,0 +1,4 @@
+# 生成链路改进
+
+- [`rag_generator.py`](./rag_generator.py) 的 `EnhancedQueryProcessor` 使用 LRU 风格缓存复用查询向量，`LLMGenerator` 与上下文优化流程均通过 `ModelRegistry` 共享模型，并引入哈希+文本相似度的去重策略。
+- [`tiered_generation.py`](./tiered_generation.py) 的 `LocalModelExecutor` 复用注册中心提供的 LLM 实例，避免多次加载大型模型。

--- a/src/generation/rag_generator.py
+++ b/src/generation/rag_generator.py
@@ -1,14 +1,18 @@
 # src/generation/rag_generator.py
 from typing import List, Dict, Optional, Tuple
 import asyncio
+from collections import OrderedDict
 from dataclasses import dataclass
-from sentence_transformers import SentenceTransformer
-import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig
+import hashlib
+from threading import Lock
+from difflib import SequenceMatcher
+from transformers import GenerationConfig
 from loguru import logger
 import json
 from pathlib import Path
 import re
+
+from src.optimization.model_registry import ModelRegistry
 
 # Assuming these classes are in their respective files as per the project structure
 from src.retrieval.vector_database import VectorDatabaseManager
@@ -38,10 +42,23 @@ class GenerationResult:
     total_cost: Optional[float] = None
 
 class EnhancedQueryProcessor:
-    """增强的查询处理器 - 集成查询智能"""
-    def __init__(self, embedding_model: str = "BAAI/bge-m3", config: Optional[Dict] = None):
-        self.embedder = SentenceTransformer(embedding_model)
-        
+    """增强的查询处理器 - 集成查询智能并缓存查询向量"""
+
+    def __init__(
+        self,
+        embedding_model: str = "BAAI/bge-m3",
+        config: Optional[Dict] = None,
+    ):
+        resolved_device = config.get('device', 'auto') if config else 'auto'
+        self.embedder = ModelRegistry.get_sentence_transformer(
+            embedding_model, device=resolved_device
+        )
+
+        # Query vector cache prevents repeated encoding of the same prompts
+        self._cache_lock: Lock = Lock()
+        self._vector_cache: OrderedDict[str, object] = OrderedDict()
+        self._cache_size = (config or {}).get('query_vector_cache_size', 256)
+
         # Initialize Query Intelligence Engine if config provided
         self.query_intelligence = None
         if config:
@@ -49,17 +66,40 @@ class EnhancedQueryProcessor:
                 self.query_intelligence = QueryIntelligenceEngine(config)
                 logger.info("Enhanced Query Processor with Intelligence initialized.")
             except Exception as e:
-                logger.warning(f"Query Intelligence initialization failed: {e}. Using basic processing.")
+                logger.warning(
+                    f"Query Intelligence initialization failed: {e}. Using basic processing."
+                )
         else:
             logger.info("Basic Query Processor initialized.")
-    
+
+    def _get_cached_vector(self, text: str):
+        cache_key = text.strip()
+        with self._cache_lock:
+            if cache_key in self._vector_cache:
+                self._vector_cache.move_to_end(cache_key)
+                return self._vector_cache[cache_key]
+
+        vector = self.embedder.encode([text], convert_to_numpy=True)[0]
+
+        with self._cache_lock:
+            self._vector_cache[cache_key] = vector
+            if len(self._vector_cache) > self._cache_size:
+                self._vector_cache.popitem(last=False)
+
+        return vector
+
+    def get_vector(self, text: str):
+        """Expose cached vector retrieval for external callers."""
+
+        return self._get_cached_vector(text)
+
     def process_query(self, query: str) -> Dict:
         language = 'zh' if re.search(r'[\u4e00-\u9fff]', query) else 'en'
-        
+
         result = {
             'original_query': query,
             'language': language,
-            'query_vector': self.embedder.encode([query], convert_to_numpy=True)[0],
+            'query_vector': self.get_vector(query),
             'processed_query': query,
             'optimized_queries': [query],
             'hyde_document': '',
@@ -167,31 +207,24 @@ ContextOptimizer = EnhancedContextOptimizer
 class LLMGenerator:
     """大语言模型生成器"""
     def __init__(
-        self, 
+        self,
         model_name: str,
         device: str = "auto",
         max_new_tokens: int = 1024,
         token: Optional[str] = None  # 新增: 接收token
     ):
         self.model_name = model_name
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        logger.info(f"Loading LLM: {model_name} on {self.device}")
-        
-        # 修改: 在加载时传递token
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True, token=token)
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_name,
-            torch_dtype="auto",
-            device_map="auto",
-            trust_remote_code=True,
-            token=token  # 修改: 在加载时传递token
-        )
-        
+        llm_resource = ModelRegistry.get_llm(model_name, device=device, token=token)
+        self.device = llm_resource.device
+        self.tokenizer = llm_resource.tokenizer
+        self.model = llm_resource.model
+        logger.info(f"Using shared LLM: {model_name} on {self.device}")
+
         self.generation_config = GenerationConfig(
             max_new_tokens=max_new_tokens, temperature=0.1, top_p=0.8, do_sample=True,
             repetition_penalty=1.1, pad_token_id=self.tokenizer.eos_token_id
         )
-        logger.success("LLM loaded.")
+        logger.success("LLM generator ready (shared instance).")
     
     def generate_answer(self, query: str, context: str) -> Tuple[str, int]:
         prompt = f"Context:\n{context}\n\nQuestion: {query}\n\nAnswer:"
@@ -245,7 +278,7 @@ class EnhancedRAGSystem:
         if query_info['optimized_queries']:
             retrieval_strategies.append('multi_query')
             for i, opt_query in enumerate(query_info['optimized_queries'][:3]):  # Limit to top 3
-                query_vector = self.query_processor.embedder.encode([opt_query], convert_to_numpy=True)[0]
+                query_vector = self.query_processor.get_vector(opt_query)
                 chunks = self.db_manager.search(
                     query_vector=query_vector,
                     query_text=opt_query,
@@ -261,7 +294,7 @@ class EnhancedRAGSystem:
         # Strategy 2: HyDE retrieval if available
         if query_info['hyde_document']:
             retrieval_strategies.append('hyde')
-            hyde_vector = self.query_processor.embedder.encode([query_info['hyde_document']], convert_to_numpy=True)[0]
+            hyde_vector = self.query_processor.get_vector(query_info['hyde_document'])
             hyde_chunks = self.db_manager.search(
                 query_vector=hyde_vector,
                 query_text=query_info['hyde_document'],
@@ -345,20 +378,52 @@ class EnhancedRAGSystem:
         )
     
     def _deduplicate_chunks(self, chunks: List[Dict]) -> List[Dict]:
-        """去重文档块，基于内容相似度"""
+        """去重文档块，优先使用chunk_id并结合内容相似度判定"""
         if not chunks:
             return []
-        
-        unique_chunks = []
-        seen_contents = set()
-        
+
+        unique_chunks: List[Dict] = []
+        seen_ids = set()
+        seen_hashes: Dict[str, str] = {}
+
         for chunk in chunks:
-            content_hash = hash(chunk['content'][:200])  # Use first 200 chars for deduplication
-            if content_hash not in seen_contents:
-                seen_contents.add(content_hash)
+            content = chunk.get('content', '') or ''
+            chunk_id = chunk.get('chunk_id')
+
+            if chunk_id and chunk_id in seen_ids:
+                continue
+
+            content_hash = hashlib.sha256(content.encode('utf-8')).hexdigest()
+            is_duplicate = False
+
+            if content_hash in seen_hashes:
+                is_duplicate = True
+            else:
+                # Compare with previously stored snippets for near-duplicate detection
+                for existing_snippet in seen_hashes.values():
+                    if self._is_similar_text(content, existing_snippet):
+                        is_duplicate = True
+                        break
+
+            if not is_duplicate:
                 unique_chunks.append(chunk)
-        
+                if chunk_id:
+                    seen_ids.add(chunk_id)
+                # Store a trimmed snippet to keep memory bounded
+                seen_hashes[content_hash] = content[:512]
+
         return unique_chunks
+
+    @staticmethod
+    def _is_similar_text(current: str, other: str, threshold: float = 0.92) -> bool:
+        if not current or not other:
+            return False
+
+        window_current = current[:500]
+        window_other = other[:500]
+
+        similarity = SequenceMatcher(None, window_current, window_other).ratio()
+        return similarity >= threshold
     
     def _calculate_confidence(self, final_chunks: List[Dict], query_info: Dict) -> float:
         """计算答案置信度"""

--- a/src/generation/tiered_generation.py
+++ b/src/generation/tiered_generation.py
@@ -5,12 +5,13 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 import re
-import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig
+from transformers import GenerationConfig
 from loguru import logger
 import openai
 from pathlib import Path
 import json
+
+from src.optimization.model_registry import ModelRegistry
 
 class TaskComplexity(Enum):
     """任务复杂度"""
@@ -261,25 +262,18 @@ class TaskRouter:
 
 class LocalModelExecutor:
     """本地模型执行器"""
-    
+
     def __init__(self, model_config: ModelConfig, device: str = "auto", token: Optional[str] = None):
         self.config = model_config
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        
-        # 加载模型
-        logger.info(f"Loading local model: {model_config.name}")
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_config.name, trust_remote_code=True, token=token
-        )
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_config.name,
-            torch_dtype="auto",
-            device_map="auto",
-            trust_remote_code=True,
-            token=token
-        )
-        
-        logger.success(f"Local model {model_config.name} loaded")
+        resource = ModelRegistry.get_llm(model_config.name, device=device, token=token)
+        self.device = resource.device
+
+        # 使用共享模型
+        logger.info(f"Local model executor using shared model: {model_config.name}")
+        self.tokenizer = resource.tokenizer
+        self.model = resource.model
+
+        logger.success(f"Local model {model_config.name} ready (shared)")
     
     async def execute(self, task: TaskRequest) -> TaskResponse:
         """执行任务"""

--- a/src/knowledge_graph/README.md
+++ b/src/knowledge_graph/README.md
@@ -1,0 +1,4 @@
+# 知识图谱改造
+
+- [`knowledge_extractor.py`](./knowledge_extractor.py) 的实体/关系抽取器共享 LLM 资源，并新增异步 `build_knowledge_graph`，通过并发抽取和数据库写入的节流来加速构图。
+- [`kg_retriever.py`](./kg_retriever.py) 改为使用注册中心提供的嵌入模型，保证与主检索流程一致。

--- a/src/knowledge_graph/kg_retriever.py
+++ b/src/knowledge_graph/kg_retriever.py
@@ -6,9 +6,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from loguru import logger
 import numpy as np
-from sentence_transformers import SentenceTransformer
 from sklearn.metrics.pairwise import cosine_similarity
 from .knowledge_extractor import KnowledgeGraphIndexer
+from src.optimization.model_registry import ModelRegistry
 
 @dataclass
 class KGRetrievalResult:
@@ -28,9 +28,9 @@ class KnowledgeGraphRetriever:
         
         # 初始化知识图谱索引器
         self.kg_indexer = KnowledgeGraphIndexer(config)
-        
+
         # 初始化embedding模型用于语义相似度计算
-        self.embedder = SentenceTransformer(
+        self.embedder = ModelRegistry.get_sentence_transformer(
             config.get('embedding_model', 'BAAI/bge-m3'),
             device=config.get('device', 'auto')
         )

--- a/src/knowledge_graph/knowledge_extractor.py
+++ b/src/knowledge_graph/knowledge_extractor.py
@@ -6,12 +6,13 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 import networkx as nx
-import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig
+from transformers import GenerationConfig
 from loguru import logger
 import sqlite3
 from datetime import datetime
 import hashlib
+
+from src.optimization.model_registry import ModelRegistry
 
 @dataclass
 class Entity:
@@ -43,25 +44,29 @@ class KnowledgeTriplet:
     confidence: float = 1.0
     source: str = ""
 
-class EntityExtractor:
-    """实体抽取器"""
-    
-    def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None):
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+class _SharedLLMComponent:
+    """Utility mixin to reuse cached LLM resources."""
+
+    def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None, component_name: str = "KG component"):
+        resource = ModelRegistry.get_llm(model_name, device=device, token=token)
+        self.device = resource.device
         self.model_name = model_name
-        
-        logger.info(f"Loading Entity Extractor: {model_name}")
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, trust_remote_code=True, token=token
+        self.tokenizer = resource.tokenizer
+        self.model = resource.model
+        logger.info(f"{component_name} using shared LLM: {model_name}")
+
+
+class EntityExtractor(_SharedLLMComponent):
+    """实体抽取器"""
+
+    def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None):
+        super().__init__(
+            model_name=model_name,
+            device=device,
+            token=token,
+            component_name="Entity Extractor"
         )
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_name,
-            torch_dtype="auto",
-            device_map="auto",
-            trust_remote_code=True,
-            token=token
-        )
-        
+
         self.generation_config = GenerationConfig(
             max_new_tokens=512,
             temperature=0.2,
@@ -208,25 +213,17 @@ Please output in the following JSON format:
         
         return entities
 
-class RelationExtractor:
+class RelationExtractor(_SharedLLMComponent):
     """关系抽取器"""
-    
+
     def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None):
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        self.model_name = model_name
-        
-        logger.info(f"Loading Relation Extractor: {model_name}")
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, trust_remote_code=True, token=token
+        super().__init__(
+            model_name=model_name,
+            device=device,
+            token=token,
+            component_name="Relation Extractor"
         )
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_name,
-            torch_dtype="auto",
-            device_map="auto",
-            trust_remote_code=True,
-            token=token
-        )
-        
+
         self.generation_config = GenerationConfig(
             max_new_tokens=512,
             temperature=0.2,
@@ -660,48 +657,110 @@ class KnowledgeGraphIndexer:
         if not self.extractors_available:
             logger.warning("KG extractors not available, skipping knowledge graph construction")
             return
-        
+
         logger.info(f"Building knowledge graph from {len(chunks)} chunks...")
-        
+        try:
+            loop = asyncio.get_running_loop()
+            if loop.is_running():
+                logger.debug("Event loop detected; using sequential KG extraction fallback")
+                totals = self._build_knowledge_graph_sequential(chunks)
+            else:
+                totals = asyncio.run(self._build_knowledge_graph_async(chunks))
+        except RuntimeError:
+            totals = asyncio.run(self._build_knowledge_graph_async(chunks))
+
+        total_entities, total_relations = totals
+
+        # 加载图到内存
+        self.kg_db.load_graph_from_db()
+
+        logger.success(f"Knowledge graph constructed: {total_entities} entities, {total_relations} relations")
+        logger.info(f"Graph stats: {self.kg_db.graph.number_of_nodes()} nodes, {self.kg_db.graph.number_of_edges()} edges")
+
+    def _build_knowledge_graph_sequential(self, chunks: List[Dict]) -> Tuple[int, int]:
         total_entities = 0
         total_relations = 0
-        
+
         for i, chunk in enumerate(chunks):
             if i % 50 == 0:
                 logger.info(f"Processing chunk {i+1}/{len(chunks)}")
-            
+
             chunk_id = chunk['chunk_id']
             content = chunk['content']
-            
+
             try:
-                # 抽取实体
                 entities = self.entity_extractor.extract_entities(content, chunk_id)
-                
-                # 存储实体
                 for entity in entities:
                     self.kg_db.store_entity(entity)
-                
                 total_entities += len(entities)
-                
-                # 抽取关系
+
+                relations = []
                 if len(entities) >= 2:
                     relations = self.relation_extractor.extract_relations(content, entities, chunk_id)
-                    
-                    # 存储关系
                     for relation in relations:
                         self.kg_db.store_relation(relation)
-                    
-                    total_relations += len(relations)
-                
+                total_relations += len(relations)
             except Exception as e:
                 logger.error(f"Error processing chunk {chunk_id}: {e}")
+
+        return total_entities, total_relations
+
+    async def _build_knowledge_graph_async(self, chunks: List[Dict]) -> Tuple[int, int]:
+        total_entities = 0
+        total_relations = 0
+        semaphore = asyncio.Semaphore(self.config.get('kg_concurrency', 2)) if hasattr(self, 'config') else asyncio.Semaphore(2)
+
+        tasks = [
+            self._extract_chunk_async(chunk, semaphore, index, len(chunks))
+            for index, chunk in enumerate(chunks)
+        ]
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for result in results:
+            if isinstance(result, Exception):
+                logger.error(f"Async KG extraction encountered an error: {result}")
                 continue
-        
-        # 加载图到内存
-        self.kg_db.load_graph_from_db()
-        
-        logger.success(f"Knowledge graph constructed: {total_entities} entities, {total_relations} relations")
-        logger.info(f"Graph stats: {self.kg_db.graph.number_of_nodes()} nodes, {self.kg_db.graph.number_of_edges()} edges")
+
+            chunk_id, entities, relations = result
+            for entity in entities:
+                self.kg_db.store_entity(entity)
+            total_entities += len(entities)
+
+            for relation in relations:
+                self.kg_db.store_relation(relation)
+            total_relations += len(relations)
+
+        return total_entities, total_relations
+
+    async def _extract_chunk_async(
+        self,
+        chunk: Dict,
+        semaphore: asyncio.Semaphore,
+        index: int,
+        total: int
+    ) -> Tuple[str, List[Entity], List[Relation]]:
+        if index % 50 == 0:
+            logger.info(f"Async KG processing chunk {index + 1}/{total}")
+
+        chunk_id = chunk['chunk_id']
+        content = chunk['content']
+
+        async with semaphore:
+            try:
+                entities = await asyncio.to_thread(self.entity_extractor.extract_entities, content, chunk_id)
+                relations: List[Relation] = []
+                if len(entities) >= 2:
+                    relations = await asyncio.to_thread(
+                        self.relation_extractor.extract_relations,
+                        content,
+                        entities,
+                        chunk_id
+                    )
+                return chunk_id, entities, relations
+            except Exception as e:
+                logger.error(f"Async KG extraction failed for chunk {chunk_id}: {e}")
+                return chunk_id, [], []
     
     def query_knowledge_graph(
         self, 

--- a/src/optimization/README.md
+++ b/src/optimization/README.md
@@ -1,0 +1,3 @@
+# 模型注册中心
+
+- [`model_registry.py`](./model_registry.py) 定义了 `ModelRegistry` 与 `LLMResource`，集中管理向量模型与生成模型的生命周期，保证各子系统通过 `get_sentence_transformer` 与 `get_llm` 复用同一个实例，避免重复加载。 

--- a/src/optimization/model_registry.py
+++ b/src/optimization/model_registry.py
@@ -1,0 +1,122 @@
+# src/optimization/model_registry.py
+"""Centralised model lifecycle management.
+
+This module exposes a :class:`ModelRegistry` utility that lazily loads
+embedding models and large language models once and reuses them across the
+project.  Many parts of the system previously instantiated their own
+``SentenceTransformer`` or ``AutoModelForCausalLM`` which resulted in
+duplicated GPU memory usage and expensive initialisation costs.  The registry
+keeps a shared cache of model instances guarded by thread locks so that
+components can obtain handles without worrying about race conditions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import Lock
+from typing import Dict, Tuple, Optional
+
+from loguru import logger
+from sentence_transformers import SentenceTransformer
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+
+
+@dataclass
+class LLMResource:
+    """Container for a loaded tokenizer/model pair."""
+
+    tokenizer: AutoTokenizer
+    model: AutoModelForCausalLM
+    device: str
+
+
+class ModelRegistry:
+    """Registry that owns heavyweight model instances.
+
+    The registry keeps two caches: one for embedding models (Sentence
+    Transformers) and one for causal language models.  Keys are derived from the
+    requested model name and the resolved execution device so the same resource
+    can be safely reused by multiple callers.
+    """
+
+    _embedding_models: Dict[Tuple[str, str], SentenceTransformer] = {}
+    _llm_models: Dict[Tuple[str, str], LLMResource] = {}
+
+    _embedding_lock: Lock = Lock()
+    _llm_lock: Lock = Lock()
+
+    @staticmethod
+    def _resolve_device(device: Optional[str]) -> str:
+        if device in (None, "auto"):
+            return "cuda" if torch.cuda.is_available() else "cpu"
+        return device
+
+    @classmethod
+    def get_sentence_transformer(
+        cls, model_name: str, device: Optional[str] = "auto"
+    ) -> SentenceTransformer:
+        """Return a shared :class:`SentenceTransformer` instance."""
+
+        resolved_device = cls._resolve_device(device)
+        cache_key = (model_name, resolved_device)
+
+        if cache_key not in cls._embedding_models:
+            with cls._embedding_lock:
+                if cache_key not in cls._embedding_models:
+                    logger.info(
+                        f"Loading embedding model '{model_name}' on {resolved_device}"
+                    )
+                    cls._embedding_models[cache_key] = SentenceTransformer(
+                        model_name, device=resolved_device
+                    )
+                else:
+                    logger.debug(
+                        f"Reusing cached embedding model '{model_name}' on"
+                        f" {resolved_device}"
+                    )
+        return cls._embedding_models[cache_key]
+
+    @classmethod
+    def get_llm(
+        cls,
+        model_name: str,
+        device: Optional[str] = "auto",
+        token: Optional[str] = None,
+    ) -> LLMResource:
+        """Return a shared tokenizer/model bundle for a causal LLM."""
+
+        resolved_device = cls._resolve_device(device)
+        cache_key = (model_name, token or "")
+
+        if cache_key not in cls._llm_models:
+            with cls._llm_lock:
+                if cache_key not in cls._llm_models:
+                    logger.info(
+                        f"Loading LLM '{model_name}' with shared registry access"
+                    )
+                    tokenizer = AutoTokenizer.from_pretrained(
+                        model_name, trust_remote_code=True, token=token
+                    )
+                    model = AutoModelForCausalLM.from_pretrained(
+                        model_name,
+                        torch_dtype="auto",
+                        device_map="auto",
+                        trust_remote_code=True,
+                        token=token,
+                    )
+                    cls._llm_models[cache_key] = LLMResource(
+                        tokenizer=tokenizer,
+                        model=model,
+                        device=resolved_device,
+                    )
+                else:
+                    logger.debug(
+                        f"Reusing cached LLM '{model_name}' with shared registry"
+                    )
+
+        return cls._llm_models[cache_key]
+
+
+__all__ = ["ModelRegistry", "LLMResource"]
+

--- a/src/processing/README.md
+++ b/src/processing/README.md
@@ -1,0 +1,4 @@
+# 文本处理增强
+
+- [`text_processor.py`](./text_processor.py) 通过异步 `process_documents` 调用 `MultiRepresentationIndexer`，同时将管线参数与模型名称对齐到 `configs/config.py`，并复用共享嵌入模型。
+- [`multi_representation_indexer.py`](./multi_representation_indexer.py) 引入异步的 `create_multi_representations`，利用 `asyncio.to_thread` 并发生成摘要与问题，同时依赖模型注册中心复用 LLM 资源。

--- a/src/processing/multi_representation_indexer.py
+++ b/src/processing/multi_representation_indexer.py
@@ -3,13 +3,13 @@ from typing import List, Dict, Optional, Tuple
 import asyncio
 from dataclasses import dataclass, field
 import numpy as np
-from sentence_transformers import SentenceTransformer
-import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig
+from transformers import GenerationConfig
 from loguru import logger
 import re
 import json
 from pathlib import Path
+
+from src.optimization.model_registry import ModelRegistry
 
 @dataclass
 class MultiRepresentationChunk:
@@ -28,29 +28,33 @@ class MultiRepresentationChunk:
     
     hypothetical_questions: List[str] = field(default_factory=list)
     questions_embeddings: List[np.ndarray] = field(default_factory=list)
-    
+
     # Semantic type for better filtering
     semantic_type: str = 'content'  # 'content', 'summary', 'question'
 
-class SummaryGenerator:
-    """文档摘要生成器"""
-    
-    def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None):
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+
+class _SharedLLMComponent:
+    """Helper mixin to reuse cached LLM instances."""
+
+    def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None, component_name: str = "LLM component"):
+        resource = ModelRegistry.get_llm(model_name, device=device, token=token)
+        self.device = resource.device
         self.model_name = model_name
-        
-        logger.info(f"Loading Summary Generator: {model_name}")
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, trust_remote_code=True, token=token
+        self.tokenizer = resource.tokenizer
+        self.model = resource.model
+        logger.info(f"{component_name} using shared model: {model_name}")
+
+class SummaryGenerator(_SharedLLMComponent):
+    """文档摘要生成器"""
+
+    def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None):
+        super().__init__(
+            model_name=model_name,
+            device=device,
+            token=token,
+            component_name="Summary Generator"
         )
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_name,
-            torch_dtype="auto",
-            device_map="auto",
-            trust_remote_code=True,
-            token=token
-        )
-        
+
         self.generation_config = GenerationConfig(
             max_new_tokens=200,  # Shorter for summaries
             temperature=0.3,
@@ -101,25 +105,17 @@ Summary:"""
             # Fallback: return first part of text
             return text[:max_length] + "..." if len(text) > max_length else text
 
-class QuestionGenerator:
+class QuestionGenerator(_SharedLLMComponent):
     """假设性问题生成器"""
-    
+
     def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None):
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        self.model_name = model_name
-        
-        logger.info(f"Loading Question Generator: {model_name}")
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, trust_remote_code=True, token=token
+        super().__init__(
+            model_name=model_name,
+            device=device,
+            token=token,
+            component_name="Question Generator"
         )
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_name,
-            torch_dtype="auto",
-            device_map="auto",
-            trust_remote_code=True,
-            token=token
-        )
-        
+
         self.generation_config = GenerationConfig(
             max_new_tokens=300,
             temperature=0.4,
@@ -184,9 +180,9 @@ class MultiRepresentationIndexer:
     
     def __init__(self, config: Dict):
         self.config = config
-        
+
         # Initialize embedding model
-        self.embedder = SentenceTransformer(
+        self.embedder = ModelRegistry.get_sentence_transformer(
             config.get('embedding_model', 'BAAI/bge-m3'),
             device=config.get('device', 'auto')
         )
@@ -212,51 +208,68 @@ class MultiRepresentationIndexer:
         else:
             logger.warning("Multi-Representation Indexer initialized without LLM support")
     
-    def create_multi_representations(
-        self, 
+    async def create_multi_representations(
+        self,
         chunks: List[Dict]
     ) -> List[MultiRepresentationChunk]:
-        """为文本块创建多表示索引"""
-        logger.info(f"Creating multi-representations for {len(chunks)} chunks...")
-        
-        multi_rep_chunks = []
-        
-        for i, chunk in enumerate(chunks):
-            if i % 50 == 0:
-                logger.info(f"Processing chunk {i+1}/{len(chunks)}")
-            
-            # Create base multi-representation chunk
-            multi_chunk = MultiRepresentationChunk(
-                content=chunk['content'],
-                chunk_id=chunk['chunk_id'],
-                source_id=chunk['source_id'],
-                metadata=chunk.get('metadata', {}),
-                content_embedding=chunk.get('embedding')
-            )
-            
-            # Generate additional representations if LLM is available
-            if self.llm_available:
-                try:
-                    # Generate summary
-                    multi_chunk.summary = self.summary_generator.generate_summary(
-                        chunk['content'], max_length=150
-                    )
-                    
-                    # Generate hypothetical questions
-                    multi_chunk.hypothetical_questions = self.question_generator.generate_questions(
-                        chunk['content'], num_questions=3
-                    )
-                    
-                except Exception as e:
-                    logger.error(f"Error generating representations for chunk {chunk['chunk_id']}: {e}")
-            
-            multi_rep_chunks.append(multi_chunk)
-        
+        """为文本块创建多表示索引，使用异步生成提升吞吐"""
+        logger.info(f"Creating multi-representations for {len(chunks)} chunks asynchronously...")
+
+        semaphore = asyncio.Semaphore(self.config.get('multi_rep_concurrency', 3))
+        tasks = [
+            self._prepare_single_chunk(chunk, semaphore, index, len(chunks))
+            for index, chunk in enumerate(chunks)
+        ]
+
+        multi_rep_chunks = await asyncio.gather(*tasks)
+
         # Batch embed all representations
         self._embed_representations(multi_rep_chunks)
-        
+
         logger.success(f"Multi-representation indexing complete for {len(multi_rep_chunks)} chunks")
         return multi_rep_chunks
+
+    async def _prepare_single_chunk(
+        self,
+        chunk: Dict,
+        semaphore: asyncio.Semaphore,
+        index: int,
+        total: int
+    ) -> MultiRepresentationChunk:
+        if index % 50 == 0:
+            logger.info(f"Preparing chunk {index + 1}/{total}")
+
+        multi_chunk = MultiRepresentationChunk(
+            content=chunk['content'],
+            chunk_id=chunk['chunk_id'],
+            source_id=chunk['source_id'],
+            metadata=chunk.get('metadata', {}),
+            content_embedding=chunk.get('embedding')
+        )
+
+        if not self.llm_available:
+            return multi_chunk
+
+        async with semaphore:
+            try:
+                summary_task = asyncio.to_thread(
+                    self.summary_generator.generate_summary,
+                    chunk['content'],
+                    150
+                )
+                questions_task = asyncio.to_thread(
+                    self.question_generator.generate_questions,
+                    chunk['content'],
+                    3
+                )
+
+                summary, questions = await asyncio.gather(summary_task, questions_task)
+                multi_chunk.summary = summary
+                multi_chunk.hypothetical_questions = questions
+            except Exception as e:
+                logger.error(f"Error generating representations for chunk {chunk['chunk_id']}: {e}")
+
+        return multi_chunk
     
     def _embed_representations(self, chunks: List[MultiRepresentationChunk]):
         """批量嵌入所有表示形式"""

--- a/src/processing/text_processor.py
+++ b/src/processing/text_processor.py
@@ -3,13 +3,12 @@ import re
 from typing import List, Dict, Optional
 from dataclasses import dataclass, field
 import numpy as np
-from sentence_transformers import SentenceTransformer
-import torch
 from loguru import logger
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 import json
 from pathlib import Path
 from .multi_representation_indexer import MultiRepresentationIndexer
+from src.optimization.model_registry import ModelRegistry
 
 @dataclass
 class TextChunk:
@@ -87,16 +86,11 @@ class MultilingualEmbedder:
     多语言向量化器 (保持不变，但确认与BGE-M3模型一起使用)
     """
     def __init__(self, model_name: str = "BAAI/bge-m3", device: str = "auto"):
-        self.device = self._get_device(device)
-        logger.info(f"Loading multilingual embedding model: {model_name} on device: {self.device}")
-        self.model = SentenceTransformer(model_name, device=self.device)
+        logger.info(f"Loading multilingual embedding model: {model_name} (shared)")
+        self.model = ModelRegistry.get_sentence_transformer(model_name, device=device)
+        self.device = str(self.model.device)
         self.embedding_dim = self.model.get_sentence_embedding_dimension()
         logger.success(f"Embedder ready. Vector dimension: {self.embedding_dim}")
-
-    def _get_device(self, device: str) -> str:
-        if device == "auto":
-            return "cuda" if torch.cuda.is_available() else "cpu"
-        return device
 
     def embed_chunks(self, chunks: List[TextChunk]) -> List[TextChunk]:
         """批量向量化文本块"""
@@ -145,11 +139,11 @@ class EnhancedTextProcessor:
         else:
             logger.info("Basic Text Processor initialized")
 
-    def process_documents(self, documents: List[Dict]) -> List[Dict]:
+    async def process_documents(self, documents: List[Dict]) -> List[Dict]:
         """完整的文档处理流程 - 支持多表示索引"""
         logger.info(f"Starting to process {len(documents)} documents...")
         all_chunks = []
-        
+
         # Step 1: Split documents into chunks
         for doc in documents:
             chunks = self.splitter.split_document(
@@ -177,8 +171,8 @@ class EnhancedTextProcessor:
                 }
                 chunks_dict.append(chunk_dict)
             
-            # Create multi-representations
-            multi_rep_chunks = self.multi_rep_indexer.create_multi_representations(chunks_dict)
+            # Create multi-representations asynchronously
+            multi_rep_chunks = await self.multi_rep_indexer.create_multi_representations(chunks_dict)
             
             # Generate index entries for vector database
             index_entries = self.multi_rep_indexer.generate_index_entries(multi_rep_chunks)

--- a/src/retrieval/README.md
+++ b/src/retrieval/README.md
@@ -1,0 +1,6 @@
+# 检索模块更新
+
+- [`query_intelligence.py`](./query_intelligence.py) 各类生成器继承共享 LLM 组件，通过 `ModelRegistry` 复用 tokenizer 与模型实例。
+- [`contextual_compression.py`](./contextual_compression.py) 的句子提取器、压缩器与智能重排器统一使用共享嵌入模型，LLM 压缩器复用注册中心实例以减少显存占用。
+- [`agentic_rag.py`](./agentic_rag.py) 中的检索评估器与查询优化器共享大模型资源，避免多次加载。
+- [`vector_database.py`](./vector_database.py) 在 `_tokenize_for_search` 中新增对中文的 n-gram 切分逻辑，并允许 `build_knowledge_base` 接受预加载的 chunk 数据，以减少重复 IO。

--- a/src/retrieval/agentic_rag.py
+++ b/src/retrieval/agentic_rag.py
@@ -6,8 +6,9 @@ from enum import Enum
 import time
 import re
 from loguru import logger
-import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig
+from transformers import GenerationConfig
+
+from src.optimization.model_registry import ModelRegistry
 
 class RetrievalDecision(Enum):
     """检索决策类型"""
@@ -39,23 +40,16 @@ class AgenticStep:
 
 class RetrievalEvaluator:
     """检索质量评估器"""
-    
+
     def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None):
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        resource = ModelRegistry.get_llm(model_name, device=device, token=token)
+        self.device = resource.device
         self.model_name = model_name
-        
-        logger.info(f"Loading Retrieval Evaluator: {model_name}")
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, trust_remote_code=True, token=token
-        )
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_name,
-            torch_dtype="auto",
-            device_map="auto",
-            trust_remote_code=True,
-            token=token
-        )
-        
+
+        logger.info(f"Retrieval Evaluator using shared LLM: {model_name}")
+        self.tokenizer = resource.tokenizer
+        self.model = resource.model
+
         self.generation_config = GenerationConfig(
             max_new_tokens=400,
             temperature=0.2,
@@ -270,23 +264,16 @@ Suggested Query: [If retry is needed, provide suggested query terms]"""
 
 class QueryRefiner:
     """查询优化器"""
-    
+
     def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None):
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        resource = ModelRegistry.get_llm(model_name, device=device, token=token)
+        self.device = resource.device
         self.model_name = model_name
-        
-        logger.info(f"Loading Query Refiner: {model_name}")
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, trust_remote_code=True, token=token
-        )
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_name,
-            torch_dtype="auto", 
-            device_map="auto",
-            trust_remote_code=True,
-            token=token
-        )
-        
+
+        logger.info(f"Query Refiner using shared LLM: {model_name}")
+        self.tokenizer = resource.tokenizer
+        self.model = resource.model
+
         self.generation_config = GenerationConfig(
             max_new_tokens=200,
             temperature=0.3,

--- a/src/retrieval/contextual_compression.py
+++ b/src/retrieval/contextual_compression.py
@@ -4,11 +4,11 @@ import re
 import asyncio
 from dataclasses import dataclass
 import numpy as np
-from sentence_transformers import SentenceTransformer
-import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig
+from transformers import GenerationConfig
 from loguru import logger
 from sklearn.metrics.pairwise import cosine_similarity
+
+from src.optimization.model_registry import ModelRegistry
 
 @dataclass
 class CompressedContext:
@@ -21,11 +21,12 @@ class CompressedContext:
 
 class SentenceExtractor:
     """句子提取器 - 从文档块中提取最相关的句子"""
-    
+
     def __init__(self, embedding_model: str = "BAAI/bge-m3", device: str = "auto"):
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        self.embedder = SentenceTransformer(embedding_model, device=self.device)
-        logger.info(f"Sentence Extractor initialized with {embedding_model}")
+        self.embedder = ModelRegistry.get_sentence_transformer(
+            embedding_model, device=device
+        )
+        logger.info(f"Sentence Extractor initialized with shared {embedding_model}")
     
     def extract_relevant_sentences(
         self, 
@@ -104,23 +105,16 @@ class SentenceExtractor:
 
 class LLMCompressor:
     """基于LLM的内容压缩器"""
-    
+
     def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None):
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        resource = ModelRegistry.get_llm(model_name, device=device, token=token)
+        self.device = resource.device
         self.model_name = model_name
-        
-        logger.info(f"Loading LLM Compressor: {model_name}")
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, trust_remote_code=True, token=token
-        )
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_name,
-            torch_dtype="auto",
-            device_map="auto",
-            trust_remote_code=True,
-            token=token
-        )
-        
+
+        logger.info(f"Loading LLM Compressor via shared registry: {model_name}")
+        self.tokenizer = resource.tokenizer
+        self.model = resource.model
+
         self.generation_config = GenerationConfig(
             max_new_tokens=512,
             temperature=0.2,
@@ -315,13 +309,13 @@ class SmartReranker:
     
     def __init__(self, config: Dict):
         self.config = config
-        
+
         # Initialize embedder for semantic similarity
-        self.embedder = SentenceTransformer(
+        self.embedder = ModelRegistry.get_sentence_transformer(
             config.get('embedding_model', 'BAAI/bge-m3'),
             device=config.get('device', 'auto')
         )
-        
+
         logger.info("Smart Reranker initialized")
     
     def smart_rerank(

--- a/src/retrieval/query_intelligence.py
+++ b/src/retrieval/query_intelligence.py
@@ -4,10 +4,11 @@ import asyncio
 import re
 from dataclasses import dataclass
 from loguru import logger
-import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig
+from transformers import GenerationConfig
 import json
 from pathlib import Path
+
+from src.optimization.model_registry import ModelRegistry
 
 @dataclass
 class QueryAnalysisResult:
@@ -22,7 +23,7 @@ class QueryAnalysisResult:
 
 class QueryComplexityAnalyzer:
     """查询复杂度分析器"""
-    
+
     def __init__(self):
         self.complexity_indicators = {
             'simple': [
@@ -65,25 +66,29 @@ class QueryComplexityAnalyzer:
         else:
             return 'simple'
 
-class SubQuestionGenerator:
-    """子问题生成器"""
-    
-    def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None):
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+
+class _SharedLLMComponent:
+    """Utility mixin that reuses cached LLM instances via the registry."""
+
+    def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None, component_name: str = "LLM component"):
         self.model_name = model_name
-        
-        logger.info(f"Loading SubQuestion Generator: {model_name}")
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, trust_remote_code=True, token=token
+        resource = ModelRegistry.get_llm(model_name, device=device, token=token)
+        self.tokenizer = resource.tokenizer
+        self.model = resource.model
+        self.device = resource.device
+        logger.info(f"{component_name} using shared LLM: {model_name}")
+
+class SubQuestionGenerator(_SharedLLMComponent):
+    """子问题生成器"""
+
+    def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None):
+        super().__init__(
+            model_name=model_name,
+            device=device,
+            token=token,
+            component_name="SubQuestion Generator"
         )
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_name,
-            torch_dtype="auto",
-            device_map="auto", 
-            trust_remote_code=True,
-            token=token
-        )
-        
+
         self.generation_config = GenerationConfig(
             max_new_tokens=512,
             temperature=0.3,
@@ -144,25 +149,17 @@ Sub-questions:
             logger.error(f"Failed to generate sub-questions: {e}")
             return []
 
-class QueryRewriter:
+class QueryRewriter(_SharedLLMComponent):
     """查询重写器 - 优化检索效果"""
-    
+
     def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None):
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
-        self.model_name = model_name
-        
-        logger.info(f"Loading Query Rewriter: {model_name}")
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, trust_remote_code=True, token=token
+        super().__init__(
+            model_name=model_name,
+            device=device,
+            token=token,
+            component_name="Query Rewriter"
         )
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_name,
-            torch_dtype="auto", 
-            device_map="auto",
-            trust_remote_code=True,
-            token=token
-        )
-        
+
         self.generation_config = GenerationConfig(
             max_new_tokens=256,
             temperature=0.2,
@@ -225,25 +222,17 @@ Rewritten versions:
             logger.error(f"Failed to rewrite query: {e}")
             return [query]
 
-class HyDEGenerator:
+class HyDEGenerator(_SharedLLMComponent):
     """假设性文档嵌入生成器 (Hypothetical Document Embeddings)"""
-    
+
     def __init__(self, model_name: str, device: str = "auto", token: Optional[str] = None):
-        self.device = "cuda" if torch.cuda.is_available() else "cpu" 
-        self.model_name = model_name
-        
-        logger.info(f"Loading HyDE Generator: {model_name}")
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name, trust_remote_code=True, token=token
+        super().__init__(
+            model_name=model_name,
+            device=device,
+            token=token,
+            component_name="HyDE Generator"
         )
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_name,
-            torch_dtype="auto",
-            device_map="auto",
-            trust_remote_code=True, 
-            token=token
-        )
-        
+
         self.generation_config = GenerationConfig(
             max_new_tokens=512,
             temperature=0.7,

--- a/src/retrieval/vector_database.py
+++ b/src/retrieval/vector_database.py
@@ -160,10 +160,29 @@ class QdrantVectorDB:
     def _tokenize_for_search(self, text: str) -> List[str]:
         """为全文检索准备token"""
         import re
-        
-        # 简单的分词（可以替换为更专业的分词器）
-        tokens = re.findall(r'\b\w{3,}\b', text.lower())
-        return list(set(tokens))  # 去重
+
+        # 英文和数字分词
+        tokens = re.findall(r'\b[a-z0-9]{2,}\b', text.lower())
+
+        # 简单的中文分词，通过生成1-3字的滑动窗口
+        chinese_segments = re.findall(r'[\u4e00-\u9fa5]+', text)
+        for segment in chinese_segments:
+            tokens.extend(self._generate_chinese_tokens(segment))
+
+        return list({token for token in tokens if token})  # 去重
+
+    def _generate_chinese_tokens(self, segment: str) -> List[str]:
+        if not segment:
+            return []
+
+        tokens = set()
+        length = len(segment)
+
+        for size in (1, 2, 3):
+            for i in range(length - size + 1):
+                tokens.add(segment[i:i + size])
+
+        return list(tokens)
     
     def hybrid_search(
         self,
@@ -294,10 +313,10 @@ class VectorDatabaseManager:
             timeout=config.get('qdrant_timeout', 120) # 从配置读取或默认120秒
         )
     
-    def build_knowledge_base(self, processed_chunks_path: Path) -> bool:
+    def build_knowledge_base(self, processed_chunks_path: Path, chunks: Optional[List[Dict]] = None) -> bool:
         """
         从处理好的文本块构建知识库
-        
+
         Args:
             processed_chunks_path: 处理后的文本块JSON文件路径
             
@@ -308,8 +327,9 @@ class VectorDatabaseManager:
         
         try:
             # 加载处理后的数据
-            with open(processed_chunks_path, 'r', encoding='utf-8') as f:
-                chunks = json.load(f)
+            if chunks is None:
+                with open(processed_chunks_path, 'r', encoding='utf-8') as f:
+                    chunks = json.load(f)
             
             logger.info(f"加载到 {len(chunks)} 个文本块")
             


### PR DESCRIPTION
## Summary
- centralize model lifecycle management with a reusable registry and update generation/retrieval components to rely on shared instances
- streamline data preparation by asynchronously creating multi-representations, reusing HTTP sessions during ingestion, and driving pipeline stages from shared config values
- enhance retrieval utilities with Chinese tokenization and make evaluation fallbacks explicitly recorded in generated reports

## Testing
- `python -m compileall src`


------
https://chatgpt.com/codex/tasks/task_b_68c8ca5b9ee8832db6d7669c6d445810